### PR TITLE
Fix 0616 follow

### DIFF
--- a/src/api/tweets.js
+++ b/src/api/tweets.js
@@ -104,6 +104,7 @@ export const getUserReplies = async (id) => {
     const response = await axiosInstance.get(
       `${baseUrl}/users/${id}/replied_tweets`
     );
+    console.log("tweets.js 裡的 getUserReplies 回傳值: ", response.data);
     return response.data;
   } catch (error) {
     console.error("[Get User Replies failed]: ", error.response.data.message);
@@ -209,6 +210,7 @@ export const postTweets = async ({ description }) => {
 export const getUserLikes = async (id) => {
   try {
     const res = axiosInstance.get(`${baseUrl}/users/${id}/likes`);
+    console.log("tweets.js 裡的 getUserLikes 回傳值: ", res);
     return res;
   } catch (error) {
     console.error("[Get user like failed]: ", error.response.data.message);
@@ -254,6 +256,6 @@ export const getAllUsers = async () => {
     console.log(res);
     return res;
   } catch (error) {
-    console.error("[Get all users failed]: ", error);
+    console.error("[Get all users failed]: ", error.response.data.message);
   }
 };

--- a/src/components/AdminTweetsList/AdminTweetItem/AdminTweetItem.jsx
+++ b/src/components/AdminTweetsList/AdminTweetItem/AdminTweetItem.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable no-restricted-globals */
+// 上面這行是因為要用 confirm() 這個全局函式，先在開頭禁用相關的 ESLint 規則，免得被擋
+
 import styles from "./AdminTweetItem.module.scss";
 import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 import crossDark from 'icons/crossDark.svg'
@@ -5,12 +8,31 @@ import crossDark from 'icons/crossDark.svg'
 export default function AdminTweetItem({ id, name, account, description, createdAt, avatar, handleDeleteClick }) {
   // 拿 authToken
   const authToken = localStorage.getItem("authToken");
+
+  // 確認刪除的功能，防止管理員按錯
+  function confirmDelete(content) {
+    let result = confirm(`
+    確定要刪除以下這筆內容嗎？按下確定後將於 1 秒內刪除資料：
+    ${content}
+    `);
+    if (result) {
+      // 使用者按下確定按鈕
+      // 執行刪除資料的程式碼
+      handleDeleteClick(authToken, id)
+      console.log("已成功刪除");
+    } else {
+      // 使用者按下取消按鈕
+      // 不執行任何動作
+      console.log("已取消刪除");
+    }
+  }
+
   return (
     <div className={styles.tweetItemContainer}>
       <div className={styles.tweetItemWrapper}>
         <button
           className={styles.tweetItemCrossBtn}
-          onClick={() => { handleDeleteClick(authToken, id) }}
+          onClick={() => { confirmDelete(description) }}
         >
           <img src={crossDark} alt="crossDark.svg" />
         </button>

--- a/src/components/AdminTweetsList/AdminTweetsList.module.scss
+++ b/src/components/AdminTweetsList/AdminTweetsList.module.scss
@@ -2,7 +2,7 @@
 .ContainerForScrollbar {
   width: 100%;
   height: 100vh;
-  margin: 0 auto;
+  margin: 0 131px 0 24px;
   // 若 tweets 內容較多則出現捲軸，否則隱藏
   overflow-y: auto;
   // 不要出現橫向捲軸

--- a/src/components/Follow/FollowerCollection/FollowerCollection.jsx
+++ b/src/components/Follow/FollowerCollection/FollowerCollection.jsx
@@ -3,11 +3,11 @@ import FollowerItem from "components/Follow/FollowerItem/FollowerItem.jsx"
 
 export default function FollowerCollection({ followers, flagForRendering, setFlagForRendering }) {
   return (
-    <div className={styles.container}>
+    <div >
       {followers ? (
         followers.map((follower) => {
           const { avatar, name, introduction } = follower.Followings
-          const { id, followerId,  isFollowed } = follower
+          const { id, followerId, isFollowed } = follower
           return (
             <FollowerItem
               key={id}
@@ -21,7 +21,12 @@ export default function FollowerCollection({ followers, flagForRendering, setFla
             />
           )
         })
-      ) : '（此使用者尚未被任何人跟隨）'}
+      ) : (
+        <div className={styles.margin}>
+          <div></div>
+          <span>（此使用者尚未被任何人跟隨）</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/Follow/FollowerCollection/FollowerCollection.jsx
+++ b/src/components/Follow/FollowerCollection/FollowerCollection.jsx
@@ -1,24 +1,24 @@
-// 還沒串 dummy data
-
+import styles from "./FollowerCollection.module.scss"
 import FollowerItem from "components/Follow/FollowerItem/FollowerItem.jsx"
 
 export default function FollowerCollection({ followers }) {
-  console.log('FollowerCollection 裡面的 followers: ', followers)
   return (
-    <div>
-      {followers.map((follower) => {
-        const { avatar, name, introduction } = follower.Followings
-        const { id, isFollowed } = follower
-        return (
-          <FollowerItem
-            key={id}
-            avatar={avatar}
-            name={name}
-            introduction={introduction}
-            isFollowed={isFollowed}
-          />
-        )
-      })}
+    <div className={styles.container}>
+      {followers ? (
+        followers.map((follower) => {
+          const { avatar, name, introduction } = follower.Followings
+          const { id, isFollowed } = follower
+          return (
+            <FollowerItem
+              key={id}
+              avatar={avatar}
+              name={name}
+              introduction={introduction}
+              isFollowed={isFollowed}
+            />
+          )
+        })
+      ) : '（此使用者尚未被任何人跟隨）'}
     </div>
   )
 }

--- a/src/components/Follow/FollowerCollection/FollowerCollection.jsx
+++ b/src/components/Follow/FollowerCollection/FollowerCollection.jsx
@@ -1,20 +1,23 @@
 import styles from "./FollowerCollection.module.scss"
 import FollowerItem from "components/Follow/FollowerItem/FollowerItem.jsx"
 
-export default function FollowerCollection({ followers }) {
+export default function FollowerCollection({ followers, flagForRendering, setFlagForRendering }) {
   return (
     <div className={styles.container}>
       {followers ? (
         followers.map((follower) => {
           const { avatar, name, introduction } = follower.Followings
-          const { id, isFollowed } = follower
+          const { id, followerId,  isFollowed } = follower
           return (
             <FollowerItem
               key={id}
+              id={followerId}
               avatar={avatar}
               name={name}
               introduction={introduction}
               isFollowed={isFollowed}
+              flagForRendering={flagForRendering}
+              setFlagForRendering={setFlagForRendering}
             />
           )
         })

--- a/src/components/Follow/FollowerCollection/FollowerCollection.module.scss
+++ b/src/components/Follow/FollowerCollection/FollowerCollection.module.scss
@@ -1,0 +1,3 @@
+.container {
+  margin-top: 3rem;
+}

--- a/src/components/Follow/FollowerCollection/FollowerCollection.module.scss
+++ b/src/components/Follow/FollowerCollection/FollowerCollection.module.scss
@@ -1,3 +1,3 @@
-.container {
-  margin-top: 3rem;
+.margin {
+  margin: 3rem 0rem;
 }

--- a/src/components/Follow/FollowerItem/FollowerItem.jsx
+++ b/src/components/Follow/FollowerItem/FollowerItem.jsx
@@ -1,10 +1,48 @@
-// 還沒串資料
 import styles from "./FollowerItem.module.scss";
 import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 import following from 'icons/following.svg'
 import follow from 'icons/follow.svg'
+// API
+import { postUserFollow, deleteUserFollow } from "api/tweets";
 
-export default function FollowerItem({ avatar, name, introduction, isFollowed }) {
+export default function FollowerItem({ id, avatar, name, introduction, isFollowed, flagForRendering, setFlagForRendering }) {
+  // 拿 authToken
+  const authToken = localStorage.getItem("authToken");
+  // userInfo 資料從 localStorage 拿
+  const savedUserInfoParsed = JSON.parse(localStorage.getItem("userInfo"))
+  const savedUserId = savedUserInfoParsed && savedUserInfoParsed.id
+
+  // 去撈跟隨 API
+  const postUserFollowAsync = async (authToken, id) => {
+    try {
+      const res = await postUserFollow(authToken, id)
+      console.log(res)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  // 去撈取消跟隨 API
+  const deleteUserFollowAsync = async (authToken, id) => {
+    try {
+      const res = await deleteUserFollow(authToken, id)
+      console.log(res)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  // 追蹤按鈕邏輯
+  async function handleFollowClick(idTopUserReceived, isFollowed) {
+    if (isFollowed) {
+      await deleteUserFollowAsync(authToken, idTopUserReceived)
+    } else {
+      await postUserFollowAsync(authToken, idTopUserReceived)
+    }
+    await setFlagForRendering(!flagForRendering)
+  }
+
+
   return (
     <div className={styles.followerItemContainer}>
       <div className={styles.followerItemWrapper}>
@@ -14,7 +52,16 @@ export default function FollowerItem({ avatar, name, introduction, isFollowed })
         <div className={styles.followerItemInfoWrapper}>
           <div className={styles.followerItemNameFollowWrapper}>
             <div className={styles.followerItemName}>{name}</div>
-            <button className={styles.followerItemFollowBtn}>
+            <button
+              className={styles.followerItemFollowBtn}
+              onClick={() => {
+                if (id === savedUserId) {
+                  alert('使用者不能跟隨自己哦，請跟隨其他使用者吧～')
+                } else {
+                  handleFollowClick(id, isFollowed)
+                }
+              }}
+            >
               {isFollowed ? <img src={following} alt="following.svg" /> : <img src={follow} alt="follow.svg" />}
             </button>
           </div>

--- a/src/components/Follow/FollowingCollection/FollowingCollection.jsx
+++ b/src/components/Follow/FollowingCollection/FollowingCollection.jsx
@@ -1,12 +1,10 @@
-// 要記得做跟隨顯示邏輯
-
+import styles from "./FollowingCollection.module.scss"
 import FollowingItem from "components/Follow/FollowingItem/FollowingItem.jsx"
 
 export default function FollowingCollection({ followings }) {
-  console.log('FollowingCollection 裡面的 followings: ', followings)
   return (
-    <div>
-      {followings.map((following) => {
+    <div className={styles.container}>
+      {followings ? (followings.map((following) => {
         const { avatar, name, introduction } = following.Followers
         const { id, isFollowed } = following
         return (
@@ -18,7 +16,7 @@ export default function FollowingCollection({ followings }) {
             isFollowed={isFollowed}
           />
         )
-      })}
+      })) : '（此使用者尚未跟隨任何人）'}
     </div>
   )
 }

--- a/src/components/Follow/FollowingCollection/FollowingCollection.jsx
+++ b/src/components/Follow/FollowingCollection/FollowingCollection.jsx
@@ -1,19 +1,22 @@
 import styles from "./FollowingCollection.module.scss"
 import FollowingItem from "components/Follow/FollowingItem/FollowingItem.jsx"
 
-export default function FollowingCollection({ followings }) {
+export default function FollowingCollection({ followings, flagForRendering, setFlagForRendering }) {
   return (
     <div className={styles.container}>
       {followings ? (followings.map((following) => {
         const { avatar, name, introduction } = following.Followers
-        const { id, isFollowed } = following
+        const { id, followingId, isFollowed } = following
         return (
           <FollowingItem
             key={id}
+            id={followingId}
             avatar={avatar}
             name={name}
             introduction={introduction}
             isFollowed={isFollowed}
+            flagForRendering={flagForRendering}
+            setFlagForRendering={setFlagForRendering}
           />
         )
       })) : '（此使用者尚未跟隨任何人）'}

--- a/src/components/Follow/FollowingCollection/FollowingCollection.jsx
+++ b/src/components/Follow/FollowingCollection/FollowingCollection.jsx
@@ -3,7 +3,7 @@ import FollowingItem from "components/Follow/FollowingItem/FollowingItem.jsx"
 
 export default function FollowingCollection({ followings, flagForRendering, setFlagForRendering }) {
   return (
-    <div className={styles.container}>
+    <div >
       {followings ? (followings.map((following) => {
         const { avatar, name, introduction } = following.Followers
         const { id, followingId, isFollowed } = following
@@ -19,7 +19,12 @@ export default function FollowingCollection({ followings, flagForRendering, setF
             setFlagForRendering={setFlagForRendering}
           />
         )
-      })) : '（此使用者尚未跟隨任何人）'}
+      })) : (
+        <div className={styles.margin}>
+          <div></div>
+          <span>（此使用者尚未跟隨任何人）</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/Follow/FollowingCollection/FollowingCollection.module.scss
+++ b/src/components/Follow/FollowingCollection/FollowingCollection.module.scss
@@ -1,0 +1,3 @@
+.container {
+  margin-top: 3rem;
+}

--- a/src/components/Follow/FollowingCollection/FollowingCollection.module.scss
+++ b/src/components/Follow/FollowingCollection/FollowingCollection.module.scss
@@ -1,3 +1,3 @@
-.container {
-  margin-top: 3rem;
+.margin {
+  margin: 3rem 0rem;
 }

--- a/src/components/Follow/FollowingItem/FollowingItem.jsx
+++ b/src/components/Follow/FollowingItem/FollowingItem.jsx
@@ -1,10 +1,49 @@
-// 還沒串資料
 import styles from "./FollowingItem.module.scss";
 import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 import following from 'icons/following.svg'
 import follow from 'icons/follow.svg'
+// API
+import { postUserFollow, deleteUserFollow } from "api/tweets";
 
-export default function FollowingItem({ avatar, name, introduction, isFollowed }) {
+export default function FollowingItem({ id, avatar, name, introduction, isFollowed, flagForRendering, setFlagForRendering }) {
+  // 拿 authToken
+  const authToken = localStorage.getItem("authToken");
+  // userInfo 資料從 localStorage 拿
+  const savedUserInfoParsed = JSON.parse(localStorage.getItem("userInfo"))
+  const savedUserId = savedUserInfoParsed && savedUserInfoParsed.id
+
+  // 去撈跟隨 API
+  const postUserFollowAsync = async (authToken, id) => {
+    try {
+      const res = await postUserFollow(authToken, id)
+      console.log(res)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  // 去撈取消跟隨 API
+  const deleteUserFollowAsync = async (authToken, id) => {
+    try {
+      const res = await deleteUserFollow(authToken, id)
+      console.log(res)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  // 追蹤按鈕邏輯
+  async function handleFollowClick(idTopUserReceived, isFollowed) {
+    if (isFollowed) {
+      await deleteUserFollowAsync(authToken, idTopUserReceived)
+    } else {
+      await postUserFollowAsync(authToken, idTopUserReceived)
+    }
+    await setFlagForRendering(!flagForRendering)
+  }
+
+
+
   return (
     <div className={styles.followerItemContainer}>
       <div className={styles.followerItemWrapper}>
@@ -14,7 +53,16 @@ export default function FollowingItem({ avatar, name, introduction, isFollowed }
         <div className={styles.followerItemInfoWrapper}>
           <div className={styles.followerItemNameFollowWrapper}>
             <div className={styles.followerItemName}>{name}</div>
-            <button className={styles.followerItemFollowBtn}>
+            <button
+              className={styles.followerItemFollowBtn}
+              onClick={() => {
+                if (id === savedUserId) {
+                  alert('使用者不能跟隨自己哦，請跟隨其他使用者吧～')
+                } else {
+                  handleFollowClick(id, isFollowed)
+                }
+              }}
+            >
               {isFollowed ? <img src={following} alt="following.svg" /> : <img src={follow} alt="follow.svg" />}
             </button>
           </div>

--- a/src/components/LikeCollection/LikeCollection.jsx
+++ b/src/components/LikeCollection/LikeCollection.jsx
@@ -1,16 +1,15 @@
 // LikeCollection 的 layout 跟 TweetCollection 一樣
-// 之後要寫邏輯判斷是否為 like、發文者資訊
 import styles from "./LikeCollection.module.scss";
-import { useState } from 'react';
+// import { useState } from 'react';
 import LikeItem from "components/LikeItem/LikeItem.jsx";
-import dummyTweets from "./dummyTweets";
+// import dummyTweets from "./dummyTweets";
 
 export default function LikeCollection({ likes }) {
 
   return (
     <div className={styles.tweetCollectionContainer}>
-      {likes.map((likedTweet) => {
-        const {shortDescription, createdAt} = likedTweet
+      {likes ? (likes.map((likedTweet) => {
+        const { shortDescription, createdAt } = likedTweet
         const { name, account, avatar } = likedTweet.Tweet.User
         const { id, replyCount, likeCount } = likedTweet.Tweet
         return (
@@ -26,7 +25,7 @@ export default function LikeCollection({ likes }) {
             avatar={avatar}
           />
         );
-      })}
+      })) : '（使用者尚未喜歡任何內容）'}
     </div>
   )
 }

--- a/src/components/LikeCollection/LikeCollection.jsx
+++ b/src/components/LikeCollection/LikeCollection.jsx
@@ -8,7 +8,7 @@ export default function LikeCollection({ likes }) {
 
   return (
     <div className={styles.tweetCollectionContainer}>
-      {likes ? (likes.map((likedTweet) => {
+      {likes.length !== 0 ? (likes.map((likedTweet) => {
         const { shortDescription, createdAt } = likedTweet
         const { name, account, avatar } = likedTweet.Tweet.User
         const { id, replyCount, likeCount } = likedTweet.Tweet
@@ -25,7 +25,12 @@ export default function LikeCollection({ likes }) {
             avatar={avatar}
           />
         );
-      })) : '（使用者尚未喜歡任何內容）'}
+      })) : (
+        <div className={styles.margin}>
+          <div></div>
+          <span>（尚未喜歡任何內容）</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/LikeCollection/LikeCollection.module.scss
+++ b/src/components/LikeCollection/LikeCollection.module.scss
@@ -5,3 +5,7 @@
   border-left: 1px solid #E6ECF0;
   border-right: 1px solid #E6ECF0;
 }
+
+.margin {
+  margin: 3rem 0rem;
+}

--- a/src/components/ReplyCollection/ReplyCollection.jsx
+++ b/src/components/ReplyCollection/ReplyCollection.jsx
@@ -12,7 +12,7 @@ export default function ReplyCollection({ tweetReplyList, singleTweetInfo }) {
 
   return (
     <div className={styles.replyCollectionContainer}>
-      {tweetReplyList.map((reply) => {
+      {tweetReplyList?(tweetReplyList.map((reply) => {
         const { id, comment, createdAt } = reply
 
         let userAvatar = ''
@@ -48,7 +48,7 @@ export default function ReplyCollection({ tweetReplyList, singleTweetInfo }) {
             replyTo={replyTo}
           />
         );
-      })}
+      })) : '（此使用者尚未回覆任何推文）'}
     </div>
   )
 }

--- a/src/components/ReplyCollectionUser/ReplyCollectionUser.jsx
+++ b/src/components/ReplyCollectionUser/ReplyCollectionUser.jsx
@@ -8,7 +8,7 @@ export default function ReplyCollection({ replies, userDetail }) {
 
   return (
     <div className={styles.replyCollectionContainer}>
-      {replies?(replies.map((reply) => {
+      {replies ? (replies.map((reply) => {
         const { name, account, avatar } = userDetail
         const { id, comment, createdAt } = reply
         const replyTo = reply.Tweet.User.account
@@ -23,7 +23,12 @@ export default function ReplyCollection({ replies, userDetail }) {
             replyTo={replyTo}
           />
         );
-      })) : '（您尚未回覆任何推文）'}
+      })) : (
+        <div className={styles.margin}>
+          <div></div>
+          <span>（尚未回覆任何推文）</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/ReplyCollectionUser/ReplyCollectionUser.jsx
+++ b/src/components/ReplyCollectionUser/ReplyCollectionUser.jsx
@@ -8,7 +8,7 @@ export default function ReplyCollection({ replies, userDetail }) {
 
   return (
     <div className={styles.replyCollectionContainer}>
-      {replies.map((reply) => {
+      {replies?(replies.map((reply) => {
         const { name, account, avatar } = userDetail
         const { id, comment, createdAt } = reply
         const replyTo = reply.Tweet.User.account
@@ -23,7 +23,7 @@ export default function ReplyCollection({ replies, userDetail }) {
             replyTo={replyTo}
           />
         );
-      })}
+      })) : '（您尚未回覆任何推文）'}
     </div>
   )
 }

--- a/src/components/ReplyCollectionUser/ReplyCollectionUser.module.scss
+++ b/src/components/ReplyCollectionUser/ReplyCollectionUser.module.scss
@@ -5,3 +5,7 @@
   border-left: 1px solid #E6ECF0;
   border-right: 1px solid #E6ECF0;
 }
+
+.margin {
+  margin: 3rem 0rem;
+}

--- a/src/components/RightBanner/RightBanner.jsx
+++ b/src/components/RightBanner/RightBanner.jsx
@@ -8,18 +8,15 @@ import follow from 'icons/follow.svg'
 import { getTopUsers, postUserFollow, deleteUserFollow } from "api/tweets";
 
 
-export default function RightBanner() {
+export default function RightBanner({ flagForRendering, setFlagForRendering }) {
   // 拿 authToken
   const authToken = localStorage.getItem("authToken");
   // userInfo 資料從 localStorage 拿
   const savedUserInfoParsed = JSON.parse(localStorage.getItem("userInfo"))
   const savedUserId = savedUserInfoParsed && savedUserInfoParsed.id
 
-  // tweets 存在這
+  // topUsers 存在這
   const [topUsers, setTopUsers] = useState([]);
-  // 本來想設置 flag，讓點擊跟隨時畫面能重新渲染，但無效，故轉採子元件設 state 方式
-  const [flagForRendering, setFlagForRendering] = useState(false);
-  console.log('flagForRendering', flagForRendering)
 
   // 去撈跟隨 API
   const postUserFollowAsync = async (authToken, id) => {
@@ -48,12 +45,11 @@ export default function RightBanner() {
     } else {
       await postUserFollowAsync(authToken, idTopUserReceived)
     }
-    setFlagForRendering(!flagForRendering)
+    await setFlagForRendering(!flagForRendering)
   }
 
-  // 透過 API 撈 topUsers 資料
+  // 透過 API 撈所有 topUsers 資料
   useEffect(() => {
-    // 所有 topUsers
     const getTopUsersAsync = async () => {
       try {
         const topUsers = await getTopUsers();
@@ -63,7 +59,9 @@ export default function RightBanner() {
       }
     };
     getTopUsersAsync()
+    console.log('讓 RightBanner 重新渲染')
   }, [flagForRendering]);
+
 
   return (
     <div className={styles.rightBannerContainer}>
@@ -98,8 +96,12 @@ function RecommendCollection({ topUsers, handleFollowClick, savedUserId }) {
 }
 
 function RecommendItem({ id, name, account, avatar, isFollowed, handleFollowClick, savedUserId }) {
-  // 暫存 isFollowed，讓點擊跟隨時畫面能即時回饋給使用者，同時往後端送資料
-  const [isFollowedTemp, setIsFollowedTemp] = useState(isFollowed);
+  // 讓使用者即時看到跟隨按鈕變化
+  const [isFollowedTemp, setIsFollowedTemp] = useState(isFollowed)
+
+  useEffect(() => {
+    setIsFollowedTemp(isFollowed)
+  }, [isFollowed]);
 
   return (
     <div className={styles.recommendItemContainer}>
@@ -118,8 +120,8 @@ function RecommendItem({ id, name, account, avatar, isFollowed, handleFollowClic
           if (id === savedUserId) {
             alert('使用者不能跟隨自己哦，請跟隨其他使用者吧～')
           } else {
-            handleFollowClick(id, isFollowed)
             setIsFollowedTemp(!isFollowedTemp)
+            handleFollowClick(id, isFollowed)
           }
         }}
       >

--- a/src/components/TopUserSection/TopUserSection.jsx
+++ b/src/components/TopUserSection/TopUserSection.jsx
@@ -1,7 +1,7 @@
 import styles from './TopUserSection.module.scss'
 import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 import dummyBackgroundImage from 'icons/dummyBackgroundImage.svg'
-import dummyUserPhoto from 'icons/dummyUserPhoto.svg'
+// import dummyUserPhoto from 'icons/dummyUserPhoto.svg'
 import editUserInfoBtn from 'icons/editUserInfoBtn.svg'
 import PrePageBtn from 'components/PrevPageBtn/PrevPageBtn.jsx'
 import { useState, useContext, useEffect, useRef } from 'react'
@@ -13,10 +13,9 @@ import AuthInput from 'components/Form/AuthInput'
 import camera from 'icons/camera.svg'
 import white_cross from 'icons/white_cross.svg'
 import { AuthContext } from 'context/AuthContext.jsx'
-import { useNavigate } from 'react-router-dom'
 
 
-export default function TopUserSection({ handleFollowDetailClick }) {
+export default function TopUserSection({ handleFollowDetailClick, followingCount, followerCount }) {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
@@ -29,12 +28,15 @@ export default function TopUserSection({ handleFollowDetailClick }) {
   const { putUserSelf, isUserEdited, getUser } = useContext(AuthContext)
 
   // userInfo 資料從 localStorage 拿
-  const savedUserInfo = localStorage.getItem("userInfo")
-  const savedUserInfoParsed = JSON.parse(savedUserInfo)
-  const savedUserInfoId = savedUserInfoParsed.id
-
+  const savedUserInfo = JSON.parse(localStorage.getItem("userInfo"))
+  const savedUserInfoId = savedUserInfo.id
   // 其他沒從 API 撈的直接用 localStorage 拿，code 才不用改太多
-  const { avatar, account, followingCount, followerCount } = savedUserInfoParsed;
+  const { account } = savedUserInfo;
+
+  // following 人數暫存在這，而 follower 人數不會因 user 行為而改變所以不用放
+  const [followingCountTemp, setFollowingCountTemp] = useState(followingCount)
+  console.log('我要看！', followingCountTemp)
+
 
   const handleShowModal = () => {
     handleShow();
@@ -92,15 +94,18 @@ export default function TopUserSection({ handleFollowDetailClick }) {
       setUserAvatar(response.data.avatar)
       setBanner(response.data.banner)
       setTweetCount(response.data.tweetCount)
+      setFollowingCountTemp(followingCount)
     }
     getUserAsync()
-  }, [savedUserInfoId, isUserEdited, getUser])
+  }, [getUser, savedUserInfoId, isUserEdited, followingCount])
+
+
   return (
     <div>
       <PrePageBtn toPage='/main' name={name} tweetCount={tweetCount} />
       <div className={styles.topUserInfoWrapper}>
         <img className={styles.topUserBanner} src={tempDataObject ? (tempDataObject.banner ? tempDataObject.banner : dummyBackgroundImage) : dummyBackgroundImage} alt="dummyBackgroundImage.svg" />
-        <img className={styles.topUserPhoto} src={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfoParsed.avatar? savedUserInfoParsed.avatar : avatarDefaultMini)} alt='avatar' />
+        <img className={styles.topUserPhoto} src={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfo.avatar ? savedUserInfo.avatar : avatarDefaultMini)} alt='avatar' />
         <button className={styles.topUserEditBtn} onClick={handleShowModal} >
           <img src={editUserInfoBtn} alt="editUserInfoBtn.svg" />
         </button>
@@ -115,7 +120,8 @@ export default function TopUserSection({ handleFollowDetailClick }) {
                 value='followings'
                 onClick={e => { handleFollowDetailClick(e.currentTarget.value) }}
               >
-                <span className={styles.topUserFollowCount}>{tempDataObject ? tempDataObject.followingCount : followingCount}</span><span className={styles.topUserFollowWord}>跟隨中</span>
+                {/* <span className={styles.topUserFollowCount}>{tempDataObject ? tempDataObject.followingCount : followingCountTemp}</span><span className={styles.topUserFollowWord}>跟隨中</span> */}
+                <span className={styles.topUserFollowCount}>{followingCountTemp ? followingCountTemp : 100}</span><span className={styles.topUserFollowWord}>跟隨中</span>
               </button>
             </div>
             <div className={styles.topUserFollowerWrapper}>
@@ -137,12 +143,12 @@ export default function TopUserSection({ handleFollowDetailClick }) {
         onIntroChange={(updateIntroInput) => updateIntroInput ? setIntro(updateIntroInput) : setIntro('')}
         onSave={handleSave}
         nameBorderLine={clsx('', { [styles.wordLengthError]: name.length > 50 }, { [styles.emptyError]: name.trim().length === 0 })}
-        introBorderLine={clsx('', { [styles.wordLengthError]: (intro? intro.length > 160 : false)}, { [styles.emptyError]: !intro})}
+        introBorderLine={clsx('', { [styles.wordLengthError]: (intro ? intro.length > 160 : false) }, { [styles.emptyError]: !intro })}
         nameValue={name}
         introValue={intro}
         handleAvatarFile={handleAvatarFile}
         handleBannerFile={handleBannerFile}
-        modalAvatar={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfoParsed.avatar? savedUserInfoParsed.avatar : avatarDefaultMini)}
+        modalAvatar={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfo.avatar ? savedUserInfo.avatar : avatarDefaultMini)}
         modalBanner={tempDataObject ? (tempDataObject.banner ? tempDataObject.banner : dummyBackgroundImage) : dummyBackgroundImage}
         handleBannerDelete={() => setBanner(null)}
       />

--- a/src/components/TopUserSection/TopUserSection.jsx
+++ b/src/components/TopUserSection/TopUserSection.jsx
@@ -35,8 +35,6 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
 
   // following 人數暫存在這，而 follower 人數不會因 user 行為而改變所以不用放
   const [followingCountTemp, setFollowingCountTemp] = useState(followingCount)
-  console.log('我要看！', followingCountTemp)
-
 
   const handleShowModal = () => {
     handleShow();
@@ -121,7 +119,7 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
                 onClick={e => { handleFollowDetailClick(e.currentTarget.value) }}
               >
                 {/* <span className={styles.topUserFollowCount}>{tempDataObject ? tempDataObject.followingCount : followingCountTemp}</span><span className={styles.topUserFollowWord}>跟隨中</span> */}
-                <span className={styles.topUserFollowCount}>{followingCountTemp ? followingCountTemp : 100}</span><span className={styles.topUserFollowWord}>跟隨中</span>
+                <span className={styles.topUserFollowCount}>{followingCountTemp && followingCountTemp}</span><span className={styles.topUserFollowWord}>跟隨中</span>
               </button>
             </div>
             <div className={styles.topUserFollowerWrapper}>

--- a/src/components/TopUserSectionOther/TopUserSectionOther.jsx
+++ b/src/components/TopUserSectionOther/TopUserSectionOther.jsx
@@ -49,15 +49,13 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
 
   // 追蹤按鈕邏輯
   async function handleFollowClick() {
-    // 因為下面元件會先改，例如 isFollowedStatus 變成 false 那這邊就是要 delete
     if (isFollowedStatus) {
-      await postUserFollowAsync(authToken, id)
-      await setFollowerCountTemp(followerCountTemp + 1)
-    } else {
       await deleteUserFollowAsync(authToken, id)
       await setFollowerCountTemp(followerCountTemp - 1)
+    } else {
+      await postUserFollowAsync(authToken, id)
+      await setFollowerCountTemp(followerCountTemp + 1)
     }
-    // await setIsFollowedStatus(!isFollowedStatus)
     await setFlagForRendering(!flagForRendering)
   }
 

--- a/src/components/TopUserSectionOther/TopUserSectionOther.jsx
+++ b/src/components/TopUserSectionOther/TopUserSectionOther.jsx
@@ -14,7 +14,7 @@ import PrePageBtn from 'components/PrevPageBtn/PrevPageBtn.jsx'
 import { postUserFollow, deleteUserFollow } from 'api/tweets'
 
 
-export default function TopUserSectionOther({ notification, handleNotiClick, userDetail, handleFollowDetailClick, followerCount, isFollowed }) {
+export default function TopUserSectionOther({ notification, handleNotiClick, userDetail, handleFollowDetailClick, followerCount, isFollowed, flagForRendering, setFlagForRendering }) {
   // 拿到該使用者資料
   const { id, name, account, avatar, introduction, followingCount, tweetCount } = userDetail
 
@@ -25,8 +25,6 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
   const [isFollowedStatus, setIsFollowedStatus] = useState(isFollowed)
   // 跟隨人數暫存在這
   const [followerCountTemp, setFollowerCountTemp] = useState(followerCount)
-  console.log('isFollowed', isFollowed)
-  console.log('isFollowedStatus', isFollowedStatus)
 
   // 去撈跟隨 API
   const postUserFollowAsync = async (authToken, id) => {
@@ -50,21 +48,24 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
 
 
   // 追蹤按鈕邏輯
-  function handleFollowClick() {
+  async function handleFollowClick() {
+    // 因為下面元件會先改，例如 isFollowedStatus 變成 false 那這邊就是要 delete
     if (isFollowedStatus) {
-      deleteUserFollowAsync(authToken, id)
-      setFollowerCountTemp(followerCountTemp - 1)
+      await postUserFollowAsync(authToken, id)
+      await setFollowerCountTemp(followerCountTemp + 1)
     } else {
-      postUserFollowAsync(authToken, id)
-      setFollowerCountTemp(followerCountTemp + 1)
+      await deleteUserFollowAsync(authToken, id)
+      await setFollowerCountTemp(followerCountTemp - 1)
     }
-    setIsFollowedStatus(!isFollowedStatus)
+    // await setIsFollowedStatus(!isFollowedStatus)
+    await setFlagForRendering(!flagForRendering)
   }
 
   useEffect(() => {
     setIsFollowedStatus(isFollowed)
     setFollowerCountTemp(followerCount);
   }, [isFollowed, followerCount]);
+
 
   return (
     <div>
@@ -84,7 +85,10 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
           {/* 跟隨按鈕，按了馬上更新畫面同時送資料到後端 */}
           <button
             className={styles.topUserEditBtn}
-            onClick={() => { handleFollowClick() }}
+            onClick={() => {
+              setIsFollowedStatus(!isFollowedStatus)
+              handleFollowClick()
+            }}
           >
             {isFollowedStatus ? <img src={following} alt="following.svg" /> : <img src={follow} alt="follow.svg" />}
           </button>

--- a/src/components/TweetCollection/TweetCollection.jsx
+++ b/src/components/TweetCollection/TweetCollection.jsx
@@ -2,13 +2,12 @@ import styles from "./TweetCollection.module.scss";
 import TweetItem from "components/TweetItem/TweetItem.jsx";
 import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 
-// import dummyTweets from "./dummyTweets";
 
 export default function TweetCollection({ tweets, fromPage }) {
 
   return (
     <div className={styles.tweetCollectionContainer}>
-      {tweets.map((tweet) => {
+      {tweets ? (tweets.map((tweet) => {
         const { name, account, avatar } = tweet.User
         const { id, UserId, description, createdAt, replyCount, likeCount, isLiked } = tweet
         return (
@@ -27,7 +26,7 @@ export default function TweetCollection({ tweets, fromPage }) {
             fromPage={fromPage}
           />
         );
-      })}
+      })) : '（此使用者尚未發佈任何推文）' }
     </div>
   )
 }

--- a/src/components/TweetCollection/TweetCollection.jsx
+++ b/src/components/TweetCollection/TweetCollection.jsx
@@ -4,10 +4,9 @@ import avatarDefaultMini from 'icons/avatarDefaultMini.svg'
 
 
 export default function TweetCollection({ tweets, fromPage }) {
-
   return (
     <div className={styles.tweetCollectionContainer}>
-      {tweets ? (tweets.map((tweet) => {
+      {tweets.length !== 0 ? (tweets.map((tweet) => {
         const { name, account, avatar } = tweet.User
         const { id, UserId, description, createdAt, replyCount, likeCount, isLiked } = tweet
         return (
@@ -26,7 +25,12 @@ export default function TweetCollection({ tweets, fromPage }) {
             fromPage={fromPage}
           />
         );
-      })) : '（此使用者尚未發佈任何推文）' }
+      })) : (
+        <div className={styles.margin}>
+          <div></div>
+          <span>（尚未發佈任何推文）</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/TweetCollection/TweetCollection.module.scss
+++ b/src/components/TweetCollection/TweetCollection.module.scss
@@ -5,3 +5,7 @@
   border-left: 1px solid #E6ECF0;
   border-right: 1px solid #E6ECF0;
 }
+
+.margin {
+  margin: 3rem 0rem;
+}

--- a/src/components/TweetItem/TweetItem.jsx
+++ b/src/components/TweetItem/TweetItem.jsx
@@ -173,7 +173,7 @@ export function ReplyTweetModal({ show, handleClose, threadUserName, threadUserA
         </Modal.Header>
         <Modal.Body className={clsx(styles.modalBody)}>
           <div className={styles.modalPost}>
-            <div className={styles.replyModaldAvatarContainer}>
+            <div className={styles.replyModalAvatarContainer}>
               <img className={styles.threadUserAvatar} src={threadUserAvatar ? threadUserAvatar : avatarDefaultMini} alt="avatarDefaultMini.svg" />
             </div>
             <div className={styles.tweetItemInfoWrapper}>

--- a/src/components/TweetItem/TweetItem.module.scss
+++ b/src/components/TweetItem/TweetItem.module.scss
@@ -224,7 +224,7 @@
   }
 }
 
-.replyModaldAvatarContainer {
+.replyModalAvatarContainer {
   position: relative;
   align-self: flex-start;
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -94,7 +94,7 @@ const AuthProvider = ({ children }) => {
   }, [pathname, isTweetUpdated, isUserEdited, navigate]);
 
 
-  console.log('AuthProvider 重新渲染')
+  // console.log('AuthProvider 重新渲染')
   return (
     <AuthContext.Provider
       value={{

--- a/src/pages/AdminUsersPage.jsx
+++ b/src/pages/AdminUsersPage.jsx
@@ -2,7 +2,7 @@ import LeftBannerAdmin from 'components/LeftBannerAdmin/LeftBannerAdmin.jsx'
 import UserCard from 'components/Admin/UserCard.jsx'
 import AdminContainer from 'components/Admin/AdminContainer.jsx'
 import AdminRightContainer from 'components/Admin/AdminRightContainer.jsx'
-import dummyUserCards from 'components/Admin/dummyUserCards.js'
+// import dummyUserCards from 'components/Admin/dummyUserCards.js'
 import { useState, useEffect } from 'react'
 import { getAllUsers } from 'api/tweets'
 

--- a/src/pages/UserOtherFollowPage.jsx
+++ b/src/pages/UserOtherFollowPage.jsx
@@ -25,6 +25,8 @@ export default function UserOtherFollowPage() {
   const [otherUserFollowers, setOtherUserFollowers] = useState([])
   const [tweetCount, setTweetCount] = useState(null)
   const [otherUserName, setOtherUserName] = useState(null)
+  // 負責觸發 UserSelfFollowPage 與 RightBanner 重新渲染
+  const [flagForRendering, setFlagForRendering] = useState(false)
 
   // 改變使用者瀏覽區塊
   function handleChangeUserContentClick(targetValue) {
@@ -69,7 +71,7 @@ export default function UserOtherFollowPage() {
     getUserFollowingsAsync();
     getUserFollowersAsync()
     getUserAsync()
-  }, [savedOtherUserId]);
+  }, [savedOtherUserId, flagForRendering]);
 
 
   return (
@@ -80,10 +82,10 @@ export default function UserOtherFollowPage() {
           <PrePageBtn toPage='/user/other' name={otherUserName} tweetCount={tweetCount} />
         </div>
         <ChangeUserContentForFollow userContent={userContent} handleChangeUserContentClick={handleChangeUserContentClick} />
-        {userContent === 'followers' && <FollowerCollection followers={otherUserFollowers} />}
-        {userContent === 'followings' && <FollowingCollection followings={otherUserFollowings} />}
+        {userContent === 'followers' && <FollowerCollection followers={otherUserFollowers} flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />}
+        {userContent === 'followings' && <FollowingCollection followings={otherUserFollowings} flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />}
       </MiddleColumnContainer>
-      <RightBanner />
+      <RightBanner flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />
     </MainContainer>
   )
 }

--- a/src/pages/UserOtherPage.jsx
+++ b/src/pages/UserOtherPage.jsx
@@ -32,6 +32,9 @@ export default function UserOtherPage() {
   // userInfo 資料從 localStorage 拿
   const savedOtherUserId = localStorage.getItem("otherUserId")
 
+  // 設置 flag 讓 TopUserSectionOther 與 RightBanner 能彼此連動
+  const [flagForRendering, setFlagForRendering] = useState(false);
+
   // 拿到該使用者資料
   let followerCount = 0
   let isFollowed = false
@@ -108,7 +111,7 @@ export default function UserOtherPage() {
       getUserLikesAsync();
       getUserAsync();
     }
-  }, [savedOtherUserId]);
+  }, [savedOtherUserId, flagForRendering]);
 
   return (
     <MainContainer>
@@ -121,13 +124,18 @@ export default function UserOtherPage() {
           handleFollowDetailClick={handleFollowDetailClick}
           followerCount={followerCount}
           isFollowed={isFollowed}
+          flagForRendering={flagForRendering}
+          setFlagForRendering={setFlagForRendering}
         />
         <ChangeUserContent userContent={userContent} handleChangeUserContentClick={handleChangeUserContentClick} />
         {userContent === 'tweets' && <TweetCollection tweets={tweets} fromPage='/user/other' />}
         {userContent === 'replies' && <ReplyCollectionUser replies={replies} userDetail={otherUserDetail} />}
         {userContent === 'likes' && <LikeCollection likes={likes} />}
       </MiddleColumnContainer>
-      <RightBanner />
+      <RightBanner
+        flagForRendering={flagForRendering}
+        setFlagForRendering={setFlagForRendering}
+      />
     </MainContainer>
   )
 }

--- a/src/pages/UserOtherPage.jsx
+++ b/src/pages/UserOtherPage.jsx
@@ -12,7 +12,7 @@ import TweetCollection from "components/TweetCollection/TweetCollection.jsx";
 import ReplyCollectionUser from 'components/ReplyCollectionUser/ReplyCollectionUser';
 import LikeCollection from 'components/LikeCollection/LikeCollection';
 // API
-import { getUserTweets, getUserReplies, getUserLikes, getUser } from '../api/tweets';
+import { getUser, getUserTweets, getUserReplies, getUserLikes } from '../api/tweets';
 
 
 export default function UserOtherPage() {

--- a/src/pages/UserOtherPage.jsx
+++ b/src/pages/UserOtherPage.jsx
@@ -66,8 +66,11 @@ export default function UserOtherPage() {
       try {
         // 用 Context 裡的 user id 去撈他的推文
         const tweets = await getUserTweets(savedOtherUserId);
-        if (tweets.length !== 0) {
+        // 多寫一層條件式判斷是否有回傳值，若無則方便顯示相關提醒字樣
+        if (tweets) {
           setTweets(tweets.map((tweet) => ({ ...tweet })));
+        } else {
+          setTweets(null)
         }
       } catch (error) {
         console.error(error);
@@ -78,8 +81,10 @@ export default function UserOtherPage() {
       try {
         // 用 Context 裡的 user id 去撈他的回覆內容
         const replies = await getUserReplies(savedOtherUserId);
-        if (replies.length !== 0) {
+        if (replies) {
           setReplies(replies.map((reply) => ({ ...reply })));
+        } else {
+          setReplies(null)
         }
       } catch (error) {
         console.error(error);
@@ -89,7 +94,11 @@ export default function UserOtherPage() {
     const getUserLikesAsync = async () => {
       try {
         const { data } = await getUserLikes(savedOtherUserId)
-        setLikes(data.map((like) => ({ ...like })))
+        if ({ data }) {
+          setLikes(data.map((like) => ({ ...like })))
+        } else {
+          setLikes(null)
+        }
       } catch (error) {
         console.error(error);
       }

--- a/src/pages/UserSelfFollowPage.jsx
+++ b/src/pages/UserSelfFollowPage.jsx
@@ -21,11 +21,13 @@ export default function UserSelfFollowPage() {
 
   // 使用者點擊瀏覽項目最新狀態
   const [userContent, setUserContent] = useState(savedFollowContent)
-  // 儲存 user other 的 followings
+  // 儲存 user 的 followings
   const [userFollowings, setUserFollowings] = useState([])
-  // 儲存 user other 的 followers
+  // 儲存 user 的 followers
   const [userFollowers, setUserFollowers] = useState([])
   const [tweetCount, setTweetCount] = useState(null)
+  // 負責觸發 UserSelfFollowPage 與 RightBanner 重新渲染
+  const [flagForRendering, setFlagForRendering] = useState(false)
 
   // 改變瀏覽區塊
   function handleChangeUserContentClick(targetValue) {
@@ -67,7 +69,7 @@ export default function UserSelfFollowPage() {
     getUserFollowingsAsync();
     getUserFollowersAsync()
     getUserAsync()
-  }, [savedUserId]);
+  }, [savedUserId, flagForRendering]);
 
   return (
     <MainContainer>
@@ -77,10 +79,10 @@ export default function UserSelfFollowPage() {
           <PrePageBtn toPage='/user/self' name={savedUserInfoParsed.name} tweetCount={tweetCount} />
         </div>
         <ChangeUserContentForFollow userContent={userContent} handleChangeUserContentClick={handleChangeUserContentClick} />
-        {userContent === 'followers' && <FollowerCollection followers={userFollowers} />}
-        {userContent === 'followings' && <FollowingCollection followings={userFollowings} />}
+        {userContent === 'followers' && <FollowerCollection followers={userFollowers} flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />}
+        {userContent === 'followings' && <FollowingCollection followings={userFollowings} flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />}
       </MiddleColumnContainer>
-      <RightBanner />
+      <RightBanner flagForRendering={flagForRendering} setFlagForRendering={setFlagForRendering} />
     </MainContainer>
   )
 }

--- a/src/pages/UserSelfFollowPage.jsx
+++ b/src/pages/UserSelfFollowPage.jsx
@@ -12,13 +12,15 @@ import FollowingCollection from 'components/Follow/FollowingCollection/Following
 import { getUserFollowings, getUserFollowers, getUser } from '../api/tweets';
 
 export default function UserSelfFollowPage() {
+  // 先從 localStorage 拿使用者在 UserOtherPage 存的 userContent 當作初始值
+  const savedFollowContent = localStorage.getItem("followContent");
   // userInfo 資料從 localStorage 拿
   const savedUserInfo = localStorage.getItem("userInfo")
   const savedUserInfoParsed = JSON.parse(savedUserInfo)
   const savedUserId = savedUserInfoParsed.id
 
   // 使用者點擊瀏覽項目最新狀態
-  const [userContent, setUserContent] = useState('followers')
+  const [userContent, setUserContent] = useState(savedFollowContent)
   // 儲存 user other 的 followings
   const [userFollowings, setUserFollowings] = useState([])
   // 儲存 user other 的 followers
@@ -36,7 +38,6 @@ export default function UserSelfFollowPage() {
     const getUserFollowingsAsync = async () => {
       try {
         const followings = await getUserFollowings(savedUserId)
-        console.log('UserOtherFollowPage 裡的 getUserFollowings 回傳值: ', followings)
         // 只會 set 一次所以不用淺拷貝
         setUserFollowings(followings)
       } catch (error) {
@@ -47,7 +48,6 @@ export default function UserSelfFollowPage() {
     const getUserFollowersAsync = async () => {
       try {
         const followers = await getUserFollowers(savedUserId)
-        console.log('UserOtherFollowPage 裡的 getUserFollowers 回傳值: ', followers)
         // 只會 set 一次所以不用淺拷貝
         setUserFollowers(followers)
       } catch (error) {

--- a/src/pages/UserSelfPage.jsx
+++ b/src/pages/UserSelfPage.jsx
@@ -13,7 +13,7 @@ import ReplyCollectionUser from 'components/ReplyCollectionUser/ReplyCollectionU
 import LikeCollection from 'components/LikeCollection/LikeCollection';
 // API
 import { getUserTweets, getUserReplies, getUserLikes } from '../api/tweets';
-import {AuthContext} from 'context/AuthContext'
+import { AuthContext } from 'context/AuthContext'
 
 
 export default function UserSelfPage() {
@@ -26,7 +26,7 @@ export default function UserSelfPage() {
   const [replies, setReplies] = useState([]);
   // 喜歡過的推特存在這
   const [likes, setLikes] = useState([]);
-  const {isUpdatedLike, isUpdatedReplies} = useContext(AuthContext)
+  const { isUpdatedLike, isUpdatedReplies } = useContext(AuthContext)
   // userInfo 資料從 localStorage 拿
   const savedUserInfo = localStorage.getItem("userInfo")
   const savedUserInfoParsed = JSON.parse(savedUserInfo)

--- a/src/pages/UserSelfPage.jsx
+++ b/src/pages/UserSelfPage.jsx
@@ -57,7 +57,12 @@ export default function UserSelfPage() {
       try {
         // 用 Context 裡的 user id 去撈他的推文
         const tweets = await getUserTweets(savedUserInfoId);
-        setTweets(tweets.map((tweet) => ({ ...tweet })));
+        // 多寫一層條件式判斷是否有回傳值，若無則方便顯示相關提醒字樣
+        if (tweets) {
+          setTweets(tweets.map((tweet) => ({ ...tweet })));
+        } else {
+          setTweets(null)
+        }
       } catch (error) {
         console.error(error);
       }
@@ -67,7 +72,11 @@ export default function UserSelfPage() {
       try {
         // 用 Context 裡的 user id 去撈他的回覆內容
         const replies = await getUserReplies(savedUserInfoId);
-        setReplies(replies.map((reply) => ({ ...reply })));
+        if (replies) {
+          setReplies(replies.map((reply) => ({ ...reply })));
+        } else {
+          setReplies(null)
+        }
       } catch (error) {
         console.error(error);
       }
@@ -76,7 +85,11 @@ export default function UserSelfPage() {
     const getUserLikesAsync = async () => {
       try {
         const { data } = await getUserLikes(savedUserInfoId)
-        setLikes(data.map((like) => ({ ...like })))
+        if ({ data }) {
+          setLikes(data.map((like) => ({ ...like })))
+        } else {
+          setLikes(null)
+        }
       } catch (error) {
         console.error(error);
       }

--- a/src/pages/UserSelfPage.jsx
+++ b/src/pages/UserSelfPage.jsx
@@ -36,18 +36,6 @@ export default function UserSelfPage() {
   // 設置 flag 讓 TopUserSectionOther 與 RightBanner 能彼此連動
   const [flagForRendering, setFlagForRendering] = useState(false);
 
-  // const [followingCount, setFollowingCount] = useState(0);
-
-
-  // 拿到使用者資料
-  // let followingCount = 0
-  // let followerCount = 0
-  // if (userDetail && userDetail.followingCount) {
-  //   const followingCountTemp = userDetail.followingCount
-  //   setFollowingCount(followingCountTemp)
-  // }
-
-
   // 為了顯示左側按鈕顏色需做判斷，共有 1、2、3
   const currentPage = 2
 


### PR DESCRIPTION
完成：
user self 與 other 的 follow 頁面若無 followings 或 followers 則會出錯
user other 中間跟隨與 right banner 跟隨邏輯未連動
在 user self 頁面時，若在 right banner 使用跟隨按鈕，following 數字能正確變化
userSelf follow 頁的跟隨按鈕
userOther follow 頁的跟隨按鈕
user self 或 other 的 follow 頁面會跑版
所有會需要渲染陣列內容的地方都加上無內容的管理，渲染相關訊息，例如該使用者未跟隨任何人
admin AdminTweetsList 樣式微調
管理員刪除推文時應該要有提醒視窗，若不刪除則可以取消