### PR TITLE
Fix minor ux optimize

### DIFF
--- a/src/components/Form/AuthInput.jsx
+++ b/src/components/Form/AuthInput.jsx
@@ -23,7 +23,7 @@ export default function AuthInput({ type, label, placeholder, className, borderL
       <input className={styles.input} type={type || "text"} placeholder={placeholder} onChange={e => onChange?.(e.target.value)} defaultValue={value} ref={inputRef} />
       <div className={clsx(styles.borderLine, borderLine)}></div>
       {/* 即時顯示目前輸入字串長度 */}
-      {inputLengthLimit && <div className={styles.inputLength}>{value.length}/{inputLengthLimit}</div>}
+      {inputLengthLimit && <div className={styles.inputLength}>{value && value.length}/{inputLengthLimit}</div>}
     </div>
   )
 }

--- a/src/components/LikeCollection/LikeCollection.jsx
+++ b/src/components/LikeCollection/LikeCollection.jsx
@@ -11,7 +11,8 @@ export default function LikeCollection({ likes }) {
       {likes? (likes.map((likedTweet) => {
         const { shortDescription, createdAt } = likedTweet
         const { name, account, avatar } = likedTweet.Tweet.User
-        const { id, replyCount, likeCount } = likedTweet.Tweet
+        const { id } = likedTweet.Tweet
+        const {replyCount, likeCount} = likedTweet
         return (
           <LikeItem
             key={id}

--- a/src/components/ReplyCollection/ReplyCollection.module.scss
+++ b/src/components/ReplyCollection/ReplyCollection.module.scss
@@ -1,9 +1,8 @@
 .replyCollectionContainer {
   width: 641px;
   // 用 padding 而不用 margin，這樣 border 才不會出現空白段
-  padding-top: 10px;
-  border-left: 1px solid #E6ECF0;
-  border-right: 1px solid #E6ECF0;
+  border-left: 1px solid #e6ecf0;
+  border-right: 1px solid #e6ecf0;
 }
 
 .margin {

--- a/src/components/RightBanner/RightBanner.module.scss
+++ b/src/components/RightBanner/RightBanner.module.scss
@@ -67,6 +67,7 @@
       // margin-right: 13px;
 
       &Name {
+        display: flex;
         font-weight: 700;
         font-size: 16px;
         line-height: 26px;
@@ -74,6 +75,7 @@
       }
 
       &Account {
+        display: flex;
         font-weight: 500;
         font-size: 14px;
         line-height: 22px;

--- a/src/components/TopReplyListSection/TopReplyListSection.jsx
+++ b/src/components/TopReplyListSection/TopReplyListSection.jsx
@@ -100,7 +100,7 @@ export default function TopReplyListSection({ singleTweetInfo }) {
           </div>
           <div className={styles.tweetItemIconWrapper}>
             <img className={styles.tweetItemIcon} src={discussion} alt="discussion.svg" onClick={handleShow} />
-          <img className={styles.tweetItemIcon} src={objectData && objectData.isLiked? likeActive : like} alt="likeActive.svg" onClick={handleLike} />
+            <img className={styles.tweetItemIcon} src={objectData && objectData.isLiked? likeActive : like} alt="likeActive.svg" onClick={handleLike} />
           </div>
         </div>
       </div>

--- a/src/components/TopReplyListSection/TopReplyListSection.module.scss
+++ b/src/components/TopReplyListSection/TopReplyListSection.module.scss
@@ -139,6 +139,7 @@
       padding-top: 16px;
       padding-bottom: 16px;
       display: flex;
+      align-items: center;
       justify-content: space-between;
 
       .tweetItemIcon {
@@ -215,6 +216,7 @@
   &TweetItemInfoWrapper {
     display: flex;
     flex-direction: column;
+    align-items: center;
     padding: 0px;
     gap: 8px;
     width: 528px;

--- a/src/components/TopUserSection/TopUserSection.jsx
+++ b/src/components/TopUserSection/TopUserSection.jsx
@@ -4,7 +4,7 @@ import dummyBackgroundImage from 'icons/dummyBackgroundImage.svg'
 // import dummyUserPhoto from 'icons/dummyUserPhoto.svg'
 import editUserInfoBtn from 'icons/editUserInfoBtn.svg'
 import PrePageBtn from 'components/PrevPageBtn/PrevPageBtn.jsx'
-import { useState, useContext, useEffect, useRef } from 'react'
+import { useState, useContext, useEffect } from 'react'
 import clsx from 'clsx'
 import Modal from 'react-bootstrap/Modal';
 import cross from 'icons/cross.svg'
@@ -31,7 +31,7 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
   const savedUserInfo = JSON.parse(localStorage.getItem("userInfo"))
   const savedUserInfoId = savedUserInfo.id
   // 其他沒從 API 撈的直接用 localStorage 拿，code 才不用改太多
-  const { account } = savedUserInfo;
+  // const { account } = savedUserInfo;
 
   // following 人數暫存在這，而 follower 人數不會因 user 行為而改變所以不用放
   const [followingCountTemp, setFollowingCountTemp] = useState(followingCount)
@@ -96,13 +96,12 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
     }
     getUserAsync()
     setIsUserEdited(false)
-    console.log("我被執行")
   }, [getUser, savedUserInfoId, setIsUserEdited, followingCount])
 
 
   return (
     <div>
-      <PrePageBtn toPage='/main' name={name} tweetCount={tweetCount} />
+      <PrePageBtn toPage='/main' name={tempDataObject && tempDataObject.name} tweetCount={tweetCount} />
       <div className={styles.topUserInfoWrapper}>
         <img className={styles.topUserBanner} src={tempDataObject ? (tempDataObject.banner ? tempDataObject.banner : dummyBackgroundImage) : dummyBackgroundImage} alt="dummyBackgroundImage.svg" />
         <img className={styles.topUserPhoto} src={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfo.avatar ? savedUserInfo.avatar : avatarDefaultMini)} alt='avatar' />
@@ -110,9 +109,9 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
           <img src={editUserInfoBtn} alt="editUserInfoBtn.svg" />
         </button>
         <div className={styles.topUserWordsWrapper}>
-          <div className={styles.topUserName}>{tempDataObject ? tempDataObject.name : name}</div>
-          <div className={styles.topUserAccount}>@{tempDataObject ? tempDataObject.account : account}</div>
-          <div className={styles.topUserIntro}>{intro}</div>
+          <div className={styles.topUserName}>{tempDataObject && tempDataObject.name}</div>
+          <div className={styles.topUserAccount}>@{tempDataObject && tempDataObject.account}</div>
+          <div className={styles.topUserIntro}>{tempDataObject && tempDataObject.introduction}</div>
           <div className={styles.topUserFollowWrapper}>
             <div>
               <button
@@ -130,7 +129,7 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
                 value='followers'
                 onClick={e => { handleFollowDetailClick(e.currentTarget.value) }}
               >
-                <span className={styles.topUserFollowCount}>{tempDataObject ? tempDataObject.followerCount : followerCount}</span><span className={styles.topUserFollowWord}>跟隨者</span>
+                <span className={styles.topUserFollowCount}>{followerCount && followerCount}</span><span className={styles.topUserFollowWord}>跟隨者</span>
               </button>
             </div>
           </div>

--- a/src/components/TopUserSection/TopUserSection.jsx
+++ b/src/components/TopUserSection/TopUserSection.jsx
@@ -23,6 +23,8 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
   const [intro, setIntro] = useState('')
   const [userAvatar, setUserAvatar] = useState(null)
   const [banner, setBanner] = useState(null)
+  const [previewAvatar, setPreviewAvatar] = useState(null)
+  const [previewBanner, setPreviewBanner] = useState(null)
   const [tweetCount, setTweetCount] = useState(null)
   const [tempDataObject, setTempDataObject] = useState(null)
   const { putUserSelf, getUser, setIsUserEdited } = useContext(AuthContext)
@@ -42,13 +44,16 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
   //點擊上傳圖片按鈕
   const handleAvatarFile = (event) => {
     setUserAvatar(event.target.files[0]);
+    setPreviewAvatar(URL.createObjectURL(event.target.files[0]))
   }
   const handleBannerFile = (event) => {
     setBanner(event.target.files[0]);
+    setPreviewBanner(URL.createObjectURL(event.target.files[0]))
   }
   //點擊儲存按鈕
   const handleSave = async () => {
-    console.log(banner)
+    setPreviewAvatar(null)
+    setPreviewBanner(null)
     // 若input空值，則返回
     if (name.trim().length === 0 || intro.trim().length === 0) return
     // 若自我介紹或是名字長度超過限制，則返回
@@ -147,8 +152,8 @@ export default function TopUserSection({ handleFollowDetailClick, followingCount
         introValue={intro}
         handleAvatarFile={handleAvatarFile}
         handleBannerFile={handleBannerFile}
-        modalAvatar={tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfo.avatar ? savedUserInfo.avatar : avatarDefaultMini)}
-        modalBanner={tempDataObject ? (tempDataObject.banner ? tempDataObject.banner : dummyBackgroundImage) : dummyBackgroundImage}
+        modalAvatar={previewAvatar? previewAvatar : (tempDataObject ? (tempDataObject.avatar ? tempDataObject.avatar : avatarDefaultMini) : (savedUserInfo.avatar ? savedUserInfo.avatar : avatarDefaultMini))}
+        modalBanner={previewBanner? previewBanner : (tempDataObject ? (tempDataObject.banner ? tempDataObject.banner : dummyBackgroundImage) : dummyBackgroundImage)}
         handleBannerDelete={() => setBanner(null)}
       />
     </div>

--- a/src/components/TopUserSectionOther/TopUserSectionOther.jsx
+++ b/src/components/TopUserSectionOther/TopUserSectionOther.jsx
@@ -16,7 +16,7 @@ import { postUserFollow, deleteUserFollow } from 'api/tweets'
 
 export default function TopUserSectionOther({ notification, handleNotiClick, userDetail, handleFollowDetailClick, followerCount, isFollowed, flagForRendering, setFlagForRendering }) {
   // 拿到該使用者資料
-  const { id, name, account, avatar, introduction, followingCount, tweetCount } = userDetail
+  const { id, name, account, avatar, banner, introduction, followingCount, tweetCount } = userDetail
 
   // 拿 authToken
   const authToken = localStorage.getItem("authToken");
@@ -69,8 +69,8 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
     <div>
       <PrePageBtn toPage='/main' name={name} tweetCount={tweetCount} />
       <div className={styles.topUserInfoWrapper}>
-        <img src={dummyBackgroundImage2} alt="dummyBackgroundImage2.svg" />
-        <img className={styles.topUserPhoto} src={avatar ? avatar : avatarDefaultMini} alt='avatar' />
+        <img className={styles.topUserBanner} src={banner? (banner? banner : dummyBackgroundImage2) : dummyBackgroundImage2} alt="dummyBackgroundImage2.svg" />
+        <img className={styles.topUserPhoto} src={avatar ? (avatar? avatar : avatarDefaultMini) : avatarDefaultMini} alt='avatar' />
         <div className={styles.topUserEditBtnWrapper}>
           <button className={styles.topUserEditBtn}>
             <img src={emailMessage} alt="emailMessage.svg" />

--- a/src/components/TopUserSectionOther/TopUserSectionOther.jsx
+++ b/src/components/TopUserSectionOther/TopUserSectionOther.jsx
@@ -69,7 +69,7 @@ export default function TopUserSectionOther({ notification, handleNotiClick, use
     <div>
       <PrePageBtn toPage='/main' name={name} tweetCount={tweetCount} />
       <div className={styles.topUserInfoWrapper}>
-        <img className={styles.topUserBanner} src={banner? (banner? banner : dummyBackgroundImage2) : dummyBackgroundImage2} alt="dummyBackgroundImage2.svg" />
+        <img className={styles.topUserBanner} src={banner? (banner? (banner? banner : dummyBackgroundImage2) : dummyBackgroundImage2) : dummyBackgroundImage2} alt="dummyBackgroundImage2.svg" />
         <img className={styles.topUserPhoto} src={avatar ? (avatar? avatar : avatarDefaultMini) : avatarDefaultMini} alt='avatar' />
         <div className={styles.topUserEditBtnWrapper}>
           <button className={styles.topUserEditBtn}>

--- a/src/components/TopUserSectionOther/TopUserSectionOther.module.scss
+++ b/src/components/TopUserSectionOther/TopUserSectionOther.module.scss
@@ -18,6 +18,12 @@
     border: 4px solid #ffffff;
   }
 
+  &Banner {
+    width: 639px;
+    height: 200px;
+    object-fit: cover;
+  }
+
   &EditBtnWrapper {
     width: 208px;
     position: absolute;


### PR DESCRIPTION
fix code to match ac and UX optimize
UserSelfPage喜歡內容的icon和數字需加上內容
編輯個人資料：按儲存會檢核，但直接按叉叉卻不會
新用戶點擊編輯個人資料時，因為要顯示目前目前輸入字數而出現錯誤
UserOther頁面Banner更動可以顯示
可註記在AC OthersPage預設為花草圖
編輯個人資料圖片預覽
fix: ReplyListPage 的 replyCollection 若沒資料畫面的 layout 怪怪的
跟隨清單若名字較長者，下方@會跑版