### PR TITLE
fix: fix a few small error display and modal input value cleanse

### DIFF
--- a/src/components/LeftBanner/LeftBanner.module.scss
+++ b/src/components/LeftBanner/LeftBanner.module.scss
@@ -43,15 +43,15 @@
 
     // 以下是 hover 效果
     .iconHome:hover {
-      content: url('../../icons/homeActive.svg');
+      content: url("../../icons/homeActive.svg");
     }
 
     .iconUserInfo:hover {
-      content: url('../../icons/userInfoActive.svg');
+      content: url("../../icons/userInfoActive.svg");
     }
 
     .iconSettings:hover {
-      content: url('../../icons/settingsActive.svg');
+      content: url("../../icons/settingsActive.svg");
     }
   }
 
@@ -103,7 +103,7 @@
   @extend %authError;
 
   &::after {
-    content: "推文不能超過140字";
+    content: "字數不可超過140字";
   }
 }
 

--- a/src/components/LikeCollection/LikeCollection.jsx
+++ b/src/components/LikeCollection/LikeCollection.jsx
@@ -9,7 +9,8 @@ export default function LikeCollection({ likes, userDetail }) {
   return (
     <div className={clsx({[styles.tweetCollectionContainer]: likes}, styles.noBorder)}>
       {likes? (likes.map((likedTweet) => {
-        const { shortDescription, createdAt, UserId } = likedTweet
+        const { shortDescription, createdAt } = likedTweet
+        const {UserId} = likedTweet.Tweet
         let { name, account, avatar } = likedTweet.Tweet.User
         // 這邊先確認likedTweet有get到資料
         if(likedTweet) {

--- a/src/components/LikeItem/LikeItem.jsx
+++ b/src/components/LikeItem/LikeItem.jsx
@@ -13,26 +13,35 @@ import {postReply} from 'api/tweets'
 import { useEffect } from "react";
 import { useContext } from "react";
 import { AuthContext } from "context/AuthContext";
+import { clear } from "@testing-library/user-event/dist/clear";
 
 export default function LikeItem({ id, avatar, name, account, description, createdAt, replyCount, likeCount }) {
   const {setIsUpdatedReplies, setIsUpdateLikes, postUnlike} = useContext(AuthContext)
   const [show, setShow] = useState(false);
-  const handleClose = () => setShow(false);
+  const handleClose = () => {
+    clearForm()
+    setShow(false)
+  }
   const handleShow = () => setShow(true);
   const [replyTweet, setReplyTweet] = useState('')
   const [errorMsg, setErrorMsg] = useState(false)
+  const clearForm = () => {
+    setReplyTweet('');
+  };
   // 送出回覆文字
   const handleSave = async () => {
     //預防空值與回覆文字限制
     if (replyTweet.length > 140) return
-    if (replyTweet.length < 1) return setErrorMsg(true)
+    if (replyTweet.trim().length < 1) return setErrorMsg(true)
     const response = await postReply(id, { comment: replyTweet })
     //若新增推文成功
     if (response.data.comment) {
+      clearForm()
       handleClose()
-      return
+      return setIsUpdatedReplies(false)
     }
     else {
+      clearForm()
       handleClose()
       return alert("新增回覆失敗")
     }
@@ -43,9 +52,11 @@ export default function LikeItem({ id, avatar, name, account, description, creat
       const response = await postUnlike(id)
       //若取消喜歡成功
       if (!response.data) {
-        return alert("取消喜歡失敗")
+        alert("取消喜歡失敗")
+        return 
       }
   }
+
   useEffect(() => {
     setIsUpdateLikes(false)
     setIsUpdatedReplies(false)
@@ -93,12 +104,13 @@ export default function LikeItem({ id, avatar, name, account, description, creat
         }
         onSave={handleSave}
         borderLine={clsx('', { [styles.wordLengthError]: replyTweet.length > 140 }, { [styles.emptyReplyError]: errorMsg })}
+        value={replyTweet}
       />
     </div>
   )
 }
 
-export function ReplyTweetModal({ show, handleClose, threadUserName, threadUserAccount, threadDescription, threadCreatedAt, threadUserAvatar, onInputChange, onSave, borderLine }) {
+export function ReplyTweetModal({ show, handleClose, threadUserName, threadUserAccount, threadDescription, threadCreatedAt, threadUserAvatar, onInputChange, onSave, borderLine, value }) {
   const savedUserInfo = localStorage.getItem("userInfo")
   const savedUserInfoParsed = JSON.parse(savedUserInfo)
   return (
@@ -131,7 +143,7 @@ export function ReplyTweetModal({ show, handleClose, threadUserName, threadUserA
           </div>
           <div className={styles.modalPost}>
             <img className={styles.avatar} src={savedUserInfoParsed.avatar? savedUserInfoParsed.avatar : avatarDefaultMini} alt="avatar" />
-            <input className={clsx(styles.modalInput)} type="text" placeholder="推你的回覆" onChange={e => onInputChange?.(e.target.value)} />
+            <input className={clsx(styles.modalInput)} type="text" placeholder="推你的回覆" onChange={e => onInputChange?.(e.target.value)} value={value} />
             <div className={borderLine}></div>
           </div>
           <TopTweetButton btnName={clsx(styles.modalSubmit)} text={"回覆"} onClick={onSave} />

--- a/src/components/LikeItem/LikeItem.module.scss
+++ b/src/components/LikeItem/LikeItem.module.scss
@@ -371,13 +371,13 @@
 .wordLengthError {
   @extend %authError;
   &::after {
-    content: "回覆推文不能超過140字";
+    content: "字數不可超過140字";
   }
 }
 
 .emptyReplyError {
   @extend %authError;
   &::after {
-    content: "推文不能為空白";
+    content: "內容不可空白";
   }
 }

--- a/src/components/TopReplyListSection/TopReplyListSection.jsx
+++ b/src/components/TopReplyListSection/TopReplyListSection.jsx
@@ -18,23 +18,31 @@ export default function TopReplyListSection({ singleTweetInfo }) {
   const [errorMsg, setErrorMsg] = useState(false)
   const [show, setShow] = useState(false);
   const [objectData, setObjectData] = useState(null)
-  const handleClose = () => setShow(false);
+  const handleClose = () => {
+    clearForm()
+    setShow(false)
+  }
   const handleShow = () => setShow(true);
+  const clearForm = () => {
+    setReplyTweet('');
+  };
 
 
     // 送出回覆文字
   const handleSave = async () => {
     //預防空值與回覆文字限制
     if (replyTweet.length > 140) return
-    if (replyTweet.length < 1) return setErrorMsg(true)
+    if (replyTweet.trim().length < 1) return setErrorMsg(true)
     const response = await postReply(objectData.id, { comment: replyTweet })
     //若新增推文成功
     if (response.data.comment) {
+      clearForm()
       handleClose()
       setObjectData({...objectData, replyCount: objectData.replyCount + 1})
       return
     }
     else {
+      clearForm()
       handleClose()
       return alert("新增回覆失敗")
     }

--- a/src/components/TopReplyListSection/TopReplyListSection.module.scss
+++ b/src/components/TopReplyListSection/TopReplyListSection.module.scss
@@ -187,7 +187,7 @@
     min-height: 443px;
     display: flex;
     flex-direction: column;
-    padding: 16px 0 16px;
+    padding: 16px 0 30px;
     .firstModalPost {
       position: relative;
       min-height: 129px;
@@ -216,7 +216,6 @@
   &TweetItemInfoWrapper {
     display: flex;
     flex-direction: column;
-    align-items: center;
     padding: 0px;
     gap: 8px;
     width: 528px;
@@ -232,7 +231,6 @@
     display: flex;
     align-items: center;
     margin-top: 16px;
-    padding-bottom: 30px;
   }
 
   &Input {
@@ -381,13 +379,13 @@
 .wordLengthError {
   @extend %authError;
   &::after {
-    content: "回覆推文不能超過140字";
+    content: "字數不可超過140字";
   }
 }
 
 .emptyReplyError {
   @extend %authError;
   &::after {
-    content: "推文不能為空白";
+    content: "內容不可空白";
   }
 }

--- a/src/components/TopTweetSection/TopTweetSection.jsx
+++ b/src/components/TopTweetSection/TopTweetSection.jsx
@@ -9,7 +9,10 @@ import { useEffect } from 'react'
 
 export default function TopTweetSection() {
   const [show, setShow] = useState(false);
-  const handleClose = () => setShow(false);
+  const handleClose = () => {
+    clearForm()
+    setShow(false)
+  }
   const handleShow = () => setShow(true);
   const [tweet, setTweet] = useState('')
   const [errorMsg, setErrorMsg] = useState(false)

--- a/src/components/TopTweetSection/TopTweetSection.module.scss
+++ b/src/components/TopTweetSection/TopTweetSection.module.scss
@@ -148,13 +148,13 @@
 .wordLengthError {
   @extend %authError;
   &::after {
-    content: "推文不能超過140字";
+    content: "字數不可超過140字";
   }
 }
 
 .emptyTweetError {
   @extend %authError;
   &::after {
-    content: "推文不能為空白";
+    content: "內容不可空白";
   }
 }

--- a/src/components/TopUserSection/TopUserSection.module.scss
+++ b/src/components/TopUserSection/TopUserSection.module.scss
@@ -252,7 +252,7 @@ input[type="file"]::-webkit-file-upload-button {
   @extend %authError;
 
   &::after {
-    content: "字數超出上限";
+    content: "字數超出上限！";
   }
 }
 

--- a/src/components/TweetItem/TweetItem.module.scss
+++ b/src/components/TweetItem/TweetItem.module.scss
@@ -374,13 +374,13 @@
 .wordLengthError {
   @extend %authError;
   &::after {
-    content: "回覆推文不能超過140字";
+    content: "字數不可超過140字";
   }
 }
 
 .emptyReplyError {
   @extend %authError;
   &::after {
-    content: "推文不能為空白";
+    content: "內容不可空白";
   }
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -185,6 +185,7 @@ const AuthProvider = ({ children }) => {
           localStorage.removeItem("otherUserId");
           localStorage.removeItem("followContent");
           localStorage.removeItem("fromPage");
+          localStorage.removeItem("userTweetAccount")
           setPayload(null);
           setIsAuthenticated(false);
         },

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -60,7 +60,7 @@ export default function AdminPage() {
       <h3 className={styles.authTitle}>{"後台登入"}</h3>
       <AuthInput
         className={styles.account}
-        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.accountBorderLineError]: errorMsg === "Error: 帳號不存在！" || errorMsg === "Error: 帳密錯誤！" || errorMsg === "帳號不存在" })}
+        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.accountBorderLineError]:  errorMsg === "Error: 帳密錯誤！" }, {[styles.accountNotExist]: errorMsg === "Error: 帳號不存在！" || errorMsg === "帳號不存在"})}
         label={"帳號"}
         placeholder={"請輸入帳號"}
         value={account}
@@ -71,7 +71,7 @@ export default function AdminPage() {
         }} />
       <AuthInput
         className={styles.password}
-        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.invalidUserBorderLine]: errorMsg === "Error: 帳號不存在！" || errorMsg === "Error: 帳密錯誤！" || errorMsg === "帳號不存在" })}
+        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.invalidUserBorderLine]:  errorMsg === "Error: 帳密錯誤！" }, {[styles.accountNotExist]: errorMsg === "Error: 帳號不存在！" || errorMsg === "帳號不存在"})}
         label={"密碼"}
         placeholder={"請輸入密碼"}
         type="password"

--- a/src/pages/AdminPage.module.scss
+++ b/src/pages/AdminPage.module.scss
@@ -28,6 +28,13 @@
       content: "帳號或密碼錯誤";
     }
   }
+
+  .accountNotExist {
+    @extend %authError;
+    &::after {
+      content: "帳號不存在";
+    }
+  }
 }
 
 .authTitle {

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -54,7 +54,7 @@ export default function LoginPage() {
       <h3 className={styles.authTitle}>{"登入 Alphitter"}</h3>
       <AuthInput
         className={styles.account}
-        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.accountBorderLineError]: errorMsg === "Error: 帳號不存在！" || errorMsg === "Error: 帳密錯誤！" || errorMsg === "帳號不存在" })}
+        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.accountBorderLineError]: errorMsg === "Error: 帳密錯誤！"}, {[styles.accountNotExit]: errorMsg === "帳號不存在" || errorMsg === "Error: 帳號不存在！"})}
         label={"帳號"}
         placeholder={"請輸入帳號"}
         value={account}
@@ -65,7 +65,7 @@ export default function LoginPage() {
         }} />
       <AuthInput
         className={styles.password}
-        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.invalidUserBorderLine]: errorMsg === "Error: 帳號不存在！" || errorMsg === "Error: 帳密錯誤！" || errorMsg === "帳號不存在" })}
+        borderLine={clsx({ [styles.borderLine]: !errorMsg.length }, { [styles.invalidUserBorderLine]: errorMsg === "Error: 帳密錯誤！" || errorMsg === "帳號不存在" }, {[styles.accountNotExit]: errorMsg === "帳號不存在" || errorMsg === "Error: 帳號不存在！"})}
         label={"密碼"}
         placeholder={"請輸入密碼"}
         type="password"

--- a/src/pages/LoginPage.module.scss
+++ b/src/pages/LoginPage.module.scss
@@ -34,6 +34,13 @@
   }
 }
 
+.accountNotExit {
+  @extend %authError;
+  &::after {
+    content: "帳號不存在";
+  }
+}
+
 .password {
   margin-bottom: 40px;
 }

--- a/src/pages/SettingPage.module.scss
+++ b/src/pages/SettingPage.module.scss
@@ -51,7 +51,7 @@
 .accountBorderLineError {
   @extend %authError;
   &::after {
-    content: "此帳號已經存在";
+    content: "account 已重複註冊！";
   }
 }
 
@@ -65,6 +65,6 @@
 .emailBorderLineError {
   @extend %authError;
   &::after {
-    content: "此Email已經存在";
+    content: "email 已重複註冊！";
   }
 }

--- a/src/pages/SignupPage.module.scss
+++ b/src/pages/SignupPage.module.scss
@@ -43,7 +43,7 @@
 .accountBorderLineError {
   @extend %authError;
   &::after {
-    content: "此帳號已經存在";
+    content: "account 已重複註冊！";
   }
 }
 
@@ -61,7 +61,7 @@
 .emailBorderLineError {
   @extend %authError;
   &::after {
-    content: "此信箱已存在";
+    content: "email 已重複註冊！";
   }
 }
 


### PR DESCRIPTION
根據昨天在Acceptance Criteria上提到的內容
- 回覆多個留言時表單需要清空 如果連續回覆兩次，表單沒有被清空 (回覆modal: UserSelf, UserOther, Main, replyListPage)
- 所有modal在關掉後，數入內容全部清空
- 回覆留言如果只有空格 需要擋住不讓使用者送出
- 登出時刪除localStorage 的userTweetAccount
- 登入時帳號不存在 需將錯誤提示改成帳號不存在 (一樣當admin登入前台帳號時)
- 所有錯誤訊息與AC一致 (login, signup, setting, 個人編輯)
- 推文和回覆時，錯誤訊息(為空以及超過字數限制)改成和AC一樣 (modal: UserSelf, UserOther, Main, replyListPage)
- replyModal username 以及錯誤訊息跑版(modal: UserSelf, UserOther, replyListPage)
- 喜歡的內容大頭貼變成user自己bug(UserId抓到自己)
